### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <emoji-java.version>3.1.3</emoji-java.version>
         <opencsv.version>3.9</opencsv.version>
         <mysql-connector-java.version>6.0.6</mysql-connector-java.version>
+        <mssql-jdbc.version>8.4.1.jre8</mssql-jdbc.version>
         <dom4j.version>2.1.3</dom4j.version>
         <spring-security-core.version>5.1.11.RELEASE</spring-security-core.version>
         <jaxen.version>1.1.6</jaxen.version>
@@ -47,6 +48,12 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql-connector-java.version}</version>
+        </dependency>
+             
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>${mssql-jdbc.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
引入jsqlserver的jdbc驱动，解决立即同步是抛出的‘java.lang.ClassNotFoundException: com.microsoft.sqlserver.jdbc.SQLServerDriver’