### PR TITLE
fix(sec): upgrade org.springframework.security:spring-security-core to 5.2.9.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <mysql-connector-java.version>6.0.6</mysql-connector-java.version>
         <mssql-jdbc.version>8.4.1.jre8</mssql-jdbc.version>
         <dom4j.version>2.1.3</dom4j.version>
-        <spring-security-core.version>5.1.11.RELEASE</spring-security-core.version>
+        <spring-security-core.version>5.2.9.RELEASE</spring-security-core.version>
         <jaxen.version>1.1.6</jaxen.version>
         <saxpath.version>1.0-FCS</saxpath.version>
         <pinyin4j.version>2.5.1</pinyin4j.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework.security:spring-security-core 5.1.11.RELEASE
- [CVE-2021-22112](https://www.oscs1024.com/hd/CVE-2021-22112)


### What did I do？
Upgrade org.springframework.security:spring-security-core from 5.1.11.RELEASE to 5.2.9.RELEASE for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS